### PR TITLE
Fixed the `A2AEndpointRouteBuilderExtensions` to use `agent` rather than `server` as a path variable name

### DIFF
--- a/src/a2a-net.Server.AspNetCore/Extensions/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/a2a-net.Server.AspNetCore/Extensions/A2AEndpointRouteBuilderExtensions.cs
@@ -21,15 +21,15 @@ namespace A2A.Server.AspNetCore;
 public static class A2AEndpointRouteBuilderExtensions
 {
 
-    internal const string ServerVariableName = "server";
+    internal const string AgentVariableName = "agent";
 
     /// <summary>
     /// Maps the A2A agent middleware to a specified route pattern.
-    /// If the pattern includes a <c>{server}</c> route variable, the middleware will resolve the server by key.
+    /// If the pattern includes a <c>{agent}</c> route variable, the middleware will resolve the agent by key.
     /// </summary>
     /// <param name="endpoints">The endpoint route builder</param>
-    /// <param name="pattern">The route pattern to map (e.g., <c>/a2a</c> or '<c>/a2a/{server}</c>')</param>
-    public static void MapA2AAgentHttpEndpoint(this IEndpointRouteBuilder endpoints, string pattern = $"/a2a/{{{ServerVariableName}}}")
+    /// <param name="pattern">The route pattern to map (e.g., <c>/a2a</c> or '<c>/a2a/{agent}</c>')</param>
+    public static void MapA2AAgentHttpEndpoint(this IEndpointRouteBuilder endpoints, string pattern = $"/a2a/{{{AgentVariableName}}}")
     {
         endpoints.Map(pattern, async context =>
         {
@@ -40,11 +40,11 @@ public static class A2AEndpointRouteBuilderExtensions
 
     /// <summary>
     /// Maps the A2A agent middleware to a specified route pattern.
-    /// If the pattern includes a <c>{server}</c> route variable, the middleware will resolve the server by key.
+    /// If the pattern includes a <c>{agent}</c> route variable, the middleware will resolve the agent by key.
     /// </summary>
     /// <param name="endpoints">The endpoint route builder</param>
-    /// <param name="pattern">The route pattern to map (e.g., <c>/a2a</c> or '<c>/a2a/{server}</c>')</param>
-    public static void MapA2AAgentWebSocketEndpoint(this IEndpointRouteBuilder endpoints, string pattern = $"/a2a/{{{ServerVariableName}}}")
+    /// <param name="pattern">The route pattern to map (e.g., <c>/a2a</c> or '<c>/a2a/{agent}</c>')</param>
+    public static void MapA2AAgentWebSocketEndpoint(this IEndpointRouteBuilder endpoints, string pattern = $"/a2a/{{{AgentVariableName}}}")
     {
         endpoints.Map(pattern, async context =>
         {

--- a/src/a2a-net.Server.AspNetCore/Services/A2AAgentHttpMiddleware.cs
+++ b/src/a2a-net.Server.AspNetCore/Services/A2AAgentHttpMiddleware.cs
@@ -47,7 +47,7 @@ public class A2AAgentHttpMiddleware
             await WriteJsonResponseAsync(new InvalidRequestError()).ConfigureAwait(false);
             return;
         }
-        var serverName = context.Request.RouteValues.TryGetValue(A2AEndpointRouteBuilderExtensions.ServerVariableName, out var value) && value is string name && !string.IsNullOrWhiteSpace(name) ? name : A2AProtocolServer.DefaultName;
+        var serverName = context.Request.RouteValues.TryGetValue(A2AEndpointRouteBuilderExtensions.AgentVariableName, out var value) && value is string name && !string.IsNullOrWhiteSpace(name) ? name : A2AProtocolServer.DefaultName;
         var server = _serverProvider.Get(serverName);
         switch (request.Method)
         {

--- a/src/a2a-net.Server.AspNetCore/Services/A2AAgentWebSocketMiddleware.cs
+++ b/src/a2a-net.Server.AspNetCore/Services/A2AAgentWebSocketMiddleware.cs
@@ -44,7 +44,7 @@ public class A2AAgentWebSocketMiddleware
             context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
             return;
         }
-        var serverName = context.Request.RouteValues.TryGetValue(A2AEndpointRouteBuilderExtensions.ServerVariableName, out var value) && value is string name && !string.IsNullOrWhiteSpace(name) ? name : A2AProtocolServer.DefaultName;
+        var serverName = context.Request.RouteValues.TryGetValue(A2AEndpointRouteBuilderExtensions.AgentVariableName, out var value) && value is string name && !string.IsNullOrWhiteSpace(name) ? name : A2AProtocolServer.DefaultName;
         var server = _serverProvider.Get(serverName);
         using var socket = await context.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
         using var jsonRpc = new JsonRpc(new WebSocketMessageHandler(socket, new SystemTextJsonFormatter()), server);


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `A2AEndpointRouteBuilderExtensions` to use `agent` rather than `server` as a path variable name