### PR TITLE
Updated the `IAgentRuntime`'s `ExecuteAsync` accept a `TaskRecord` as input parameter instead of a `Task`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/src/a2a-net.Client.Asbtractions/a2a-net.Client.Abstractions.csproj
+++ b/src/a2a-net.Client.Asbtractions/a2a-net.Client.Abstractions.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Client</RootNamespace>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Client.Http/a2a-net.Client.Http.csproj
+++ b/src/a2a-net.Client.Http/a2a-net.Client.Http.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Client</RootNamespace>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Client.WebSocket/a2a-net.Client.WebSocket.csproj
+++ b/src/a2a-net.Client.WebSocket/a2a-net.Client.WebSocket.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Client.WebSocket</RootNamespace>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Client/a2a-net.Client.csproj
+++ b/src/a2a-net.Client/a2a-net.Client.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Client</RootNamespace>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Core/a2a-net.Core.csproj
+++ b/src/a2a-net.Core/a2a-net.Core.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Client</RootNamespace>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Server.AspNetCore/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/a2a-net.Server.AspNetCore/Extensions/IApplicationBuilderExtensions.cs
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
 namespace A2A.Server.AspNetCore;
 
 /// <summary>
@@ -36,7 +39,7 @@ public static class IApplicationBuilderExtensions
                 app.Use(async (HttpContext context, RequestDelegate next) =>
                 {
                     context.Response.ContentType = MediaTypeNames.Application.Json;
-                    await context.Response.WriteAsJsonAsync(agents[0]);
+                    await context.Response.WriteAsJsonAsync(agents[0], context.RequestServices.GetRequiredService<IOptions<JsonOptions>>().Value.JsonSerializerOptions, context.RequestAborted);
                 });
             });
         }
@@ -47,7 +50,7 @@ public static class IApplicationBuilderExtensions
                 app.Use(async (HttpContext context, RequestDelegate next) =>
                 {
                     context.Response.ContentType = MediaTypeNames.Application.Json;
-                    await context.Response.WriteAsJsonAsync(agents);
+                    await context.Response.WriteAsJsonAsync(agents, context.RequestServices.GetRequiredService<IOptions<JsonOptions>>().Value.JsonSerializerOptions, context.RequestAborted);
                 });
             });
         }

--- a/src/a2a-net.Server.AspNetCore/Services/A2AAgentHttpMiddleware.cs
+++ b/src/a2a-net.Server.AspNetCore/Services/A2AAgentHttpMiddleware.cs
@@ -11,7 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.Threading;
+using System.Net;
 
 namespace A2A.Server.AspNetCore.Services;
 
@@ -22,14 +25,17 @@ public class A2AAgentHttpMiddleware
 {
 
     readonly IA2AProtocolServerProvider _serverProvider;
+    readonly JsonOptions _jsonOptions;
 
     /// <summary>
     /// Initializes a new <see cref="A2AAgentHttpMiddleware"/>
     /// </summary>
     /// <param name="serverProvider">The service used to provide <see cref="IA2AProtocolServer"/>s</param>
-    public A2AAgentHttpMiddleware(IA2AProtocolServerProvider serverProvider)
+    /// <param name="jsonOptions">The service used to access the current <see cref="JsonOptions"/></param>
+    public A2AAgentHttpMiddleware(IA2AProtocolServerProvider serverProvider, IOptions<JsonOptions> jsonOptions)
     {
         _serverProvider = serverProvider;
+        _jsonOptions = jsonOptions.Value;
     }
 
     /// <summary>
@@ -39,7 +45,11 @@ public class A2AAgentHttpMiddleware
     /// <returns>A new awaitable <see cref="System.Threading.Tasks.Task"/></returns>
     public async System.Threading.Tasks.Task InvokeAsync(HttpContext context)
     {
-        if (!HttpMethods.IsPost(context.Request.Method)) return;
+        if (!HttpMethods.IsPost(context.Request.Method))
+        {
+            context.Response.StatusCode = (int)HttpStatusCode.MethodNotAllowed;
+            return;
+        }
         var request = await JsonSerializer.DeserializeAsync<RpcRequest>(context.Request.Body, cancellationToken: context.RequestAborted);
         if (request == null)
         {
@@ -49,6 +59,11 @@ public class A2AAgentHttpMiddleware
         }
         var serverName = context.Request.RouteValues.TryGetValue(A2AEndpointRouteBuilderExtensions.AgentVariableName, out var value) && value is string name && !string.IsNullOrWhiteSpace(name) ? name : A2AProtocolServer.DefaultName;
         var server = _serverProvider.Get(serverName);
+        if (server == null)
+        {
+            context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+            return;
+        }
         switch (request.Method)
         {
             case A2AProtocol.Methods.Tasks.Send:
@@ -160,7 +175,7 @@ public class A2AAgentHttpMiddleware
         async System.Threading.Tasks.Task WriteJsonResponseAsync(object result)
         {
             context.Response.ContentType = MediaTypeNames.Application.Json;
-            await JsonSerializer.SerializeAsync(context.Response.Body, result, result.GetType(), cancellationToken: context.RequestAborted);
+            await JsonSerializer.SerializeAsync(context.Response.Body, result, result.GetType(), _jsonOptions.SerializerOptions, context.RequestAborted);
         }
 
     }

--- a/src/a2a-net.Server.AspNetCore/Services/A2AAgentHttpMiddleware.cs
+++ b/src/a2a-net.Server.AspNetCore/Services/A2AAgentHttpMiddleware.cs
@@ -21,22 +21,16 @@ namespace A2A.Server.AspNetCore.Services;
 /// <summary>
 /// Represents the middleware that handles HTTP-based JSON-RPC requests for an A2A agent
 /// </summary>
-public class A2AAgentHttpMiddleware
+/// <remarks>
+/// Initializes a new <see cref="A2AAgentHttpMiddleware"/>
+/// </remarks>
+/// <param name="serverProvider">The service used to provide <see cref="IA2AProtocolServer"/>s</param>
+/// <param name="jsonOptions">The service used to access the current <see cref="JsonOptions"/></param>
+public class A2AAgentHttpMiddleware(IA2AProtocolServerProvider serverProvider, IOptions<JsonOptions> jsonOptions)
 {
 
-    readonly IA2AProtocolServerProvider _serverProvider;
-    readonly JsonOptions _jsonOptions;
-
-    /// <summary>
-    /// Initializes a new <see cref="A2AAgentHttpMiddleware"/>
-    /// </summary>
-    /// <param name="serverProvider">The service used to provide <see cref="IA2AProtocolServer"/>s</param>
-    /// <param name="jsonOptions">The service used to access the current <see cref="JsonOptions"/></param>
-    public A2AAgentHttpMiddleware(IA2AProtocolServerProvider serverProvider, IOptions<JsonOptions> jsonOptions)
-    {
-        _serverProvider = serverProvider;
-        _jsonOptions = jsonOptions.Value;
-    }
+    readonly IA2AProtocolServerProvider _serverProvider = serverProvider;
+    readonly JsonOptions _jsonOptions = jsonOptions.Value;
 
     /// <summary>
     /// Invokes the <see cref="A2AAgentHttpMiddleware"/>

--- a/src/a2a-net.Server.AspNetCore/Services/A2AAgentWebSocketMiddleware.cs
+++ b/src/a2a-net.Server.AspNetCore/Services/A2AAgentWebSocketMiddleware.cs
@@ -18,19 +18,14 @@ namespace A2A.Server.AspNetCore.Services;
 /// <summary>
 /// Represents the middleware that handles WebSocket-based JSON-RPC requests for an A2A agent
 /// </summary>
-public class A2AAgentWebSocketMiddleware
+/// <remarks>
+/// Initializes a new <see cref="A2AAgentWebSocketMiddleware"/>
+/// </remarks>
+/// <param name="serverProvider">The service used to provide <see cref="IA2AProtocolServer"/>s</param>
+public class A2AAgentWebSocketMiddleware(IA2AProtocolServerProvider serverProvider)
 {
 
-    readonly IA2AProtocolServerProvider _serverProvider;
-
-    /// <summary>
-    /// Initializes a new <see cref="A2AAgentWebSocketMiddleware"/>
-    /// </summary>
-    /// <param name="serverProvider">The service used to provide <see cref="IA2AProtocolServer"/>s</param>
-    public A2AAgentWebSocketMiddleware(IA2AProtocolServerProvider serverProvider)
-    {
-        _serverProvider = serverProvider;
-    }
+    readonly IA2AProtocolServerProvider _serverProvider = serverProvider;
 
     /// <summary>
     /// Invokes the <see cref="A2AAgentHttpMiddleware"/>

--- a/src/a2a-net.Server.AspNetCore/a2a-net.Server.AspNetCore.csproj
+++ b/src/a2a-net.Server.AspNetCore/a2a-net.Server.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 	<OutputType>Library</OutputType>
 	<RootNamespace>A2A.Server.AspNetCore</RootNamespace>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Server.Infrastructure.Abstractions/Services/IA2AProtocolServerBuilder.cs
+++ b/src/a2a-net.Server.Infrastructure.Abstractions/Services/IA2AProtocolServerBuilder.cs
@@ -53,6 +53,13 @@ public interface IA2AProtocolServerBuilder
         where TRuntime : class, IAgentRuntime;
 
     /// <summary>
+    /// Configures the server to use the specified <see cref="IAgentRuntime"/>
+    /// </summary>
+    /// <param name="factory">A <see cref="Func{T, TResult}"/> used to create the <see cref="IAgentRuntime"/> to use</param>
+    /// <returns>The configured <see cref="IA2AProtocolServerBuilder"/></returns>
+    IA2AProtocolServerBuilder UseAgentRuntime(Func<IServiceProvider, IAgentRuntime> factory);
+
+    /// <summary>
     /// Configures the server to use the specified <see cref="ITaskEventStream"/>
     /// </summary>
     /// <typeparam name="TStream">The type of <see cref="ITaskEventStream"/> to use</typeparam>

--- a/src/a2a-net.Server.Infrastructure.Abstractions/Services/IA2AProtocolServerProvider.cs
+++ b/src/a2a-net.Server.Infrastructure.Abstractions/Services/IA2AProtocolServerProvider.cs
@@ -24,6 +24,6 @@ public interface IA2AProtocolServerProvider
     /// </summary>
     /// <param name="name">The name of the <see cref="IA2AProtocolServer"/> to get</param>
     /// <returns>The <see cref="IA2AProtocolServer"/> with the specified name</returns>
-    IA2AProtocolServer Get(string name);
+    IA2AProtocolServer? Get(string name);
 
 }

--- a/src/a2a-net.Server.Infrastructure.Abstractions/Services/IAgentRuntime.cs
+++ b/src/a2a-net.Server.Infrastructure.Abstractions/Services/IAgentRuntime.cs
@@ -25,14 +25,14 @@ public interface IAgentRuntime
     /// <param name="task">The task to execute</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
     /// <returns>A new <see cref="IAsyncEnumerable{T}"/> used to stream the content produced by the agent during the task's execution</returns>
-    IAsyncEnumerable<AgentResponseContent> ExecuteAsync(Models.Task task, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<AgentResponseContent> ExecuteAsync(TaskRecord task, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Cancels the specified task's execution
     /// </summary>
-    /// <param name="task">The task to cancel.</param>
+    /// <param name="taskId">The id of the task to cancel.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
     /// <returns>A new awaitable <see cref=" System.Threading.Tasks.Task"/></returns>
-    System.Threading.Tasks.Task CancelAsync(Models.Task task, CancellationToken cancellationToken = default);
+    System.Threading.Tasks.Task CancelAsync(string taskId, CancellationToken cancellationToken = default);
 
 }

--- a/src/a2a-net.Server.Infrastructure.Abstractions/TaskRecord.cs
+++ b/src/a2a-net.Server.Infrastructure.Abstractions/TaskRecord.cs
@@ -22,9 +22,16 @@ public record TaskRecord
 {
 
     /// <summary>
+    /// Gets/sets the task's message
+    /// </summary>
+    [Required]
+    [DataMember(Name = "message", Order = 5), JsonPropertyName("message"), JsonPropertyOrder(5), YamlMember(Alias = "message", Order = 5)]
+    public virtual Message Message { get; set; } = null!;
+
+    /// <summary>
     /// Gets/sets the push notification configuration associated with the task, used to notify external systems about task updates
     /// </summary>
-    [DataMember(Name = "notifications", Order = 5), JsonPropertyName("notifications"), JsonPropertyOrder(5), YamlMember(Alias = "notifications", Order = 5)]
+    [DataMember(Name = "notifications", Order = 6), JsonPropertyName("notifications"), JsonPropertyOrder(6), YamlMember(Alias = "notifications", Order = 6)]
     public virtual PushNotificationConfiguration? Notifications { get; set; }
 
 }

--- a/src/a2a-net.Server.Infrastructure.Abstractions/Usings.cs
+++ b/src/a2a-net.Server.Infrastructure.Abstractions/Usings.cs
@@ -11,11 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-global using Microsoft.Extensions.DependencyInjection;
 global using A2A.Events;
 global using A2A.Models;
-global using A2A.Requests;
-global using StreamJsonRpc;
+global using Microsoft.Extensions.DependencyInjection;
+global using System.ComponentModel.DataAnnotations;
 global using System.Runtime.Serialization;
 global using System.Text.Json.Serialization;
 global using YamlDotNet.Serialization;

--- a/src/a2a-net.Server.Infrastructure.Abstractions/a2a-net.Server.Infrastructure.Abstractions.csproj
+++ b/src/a2a-net.Server.Infrastructure.Abstractions/a2a-net.Server.Infrastructure.Abstractions.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Server.Infrastructure</RootNamespace>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Server.Infrastructure.DistributedCache/a2a-net.Server.Infrastructure.DistributedCache.csproj
+++ b/src/a2a-net.Server.Infrastructure.DistributedCache/a2a-net.Server.Infrastructure.DistributedCache.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Server.Infrastructure.DistributedCache</RootNamespace>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Server/Extensions/IServiceCollectionExtensions.cs
+++ b/src/a2a-net.Server/Extensions/IServiceCollectionExtensions.cs
@@ -38,12 +38,15 @@ public static class IServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to configure</param>
     /// <param name="setup">An <see cref="Action{T}"/> used to setup the <see cref="AgentCard"/> that describes the well known A2A agent to add</param>
     /// <returns>The configured <see cref="IServiceCollection"/></returns>
-    public static IServiceCollection AddA2AWellKnownAgent(this IServiceCollection services, Action<IAgentCardBuilder> setup)
+    public static IServiceCollection AddA2AWellKnownAgent(this IServiceCollection services, Action<IServiceProvider, IAgentCardBuilder> setup)
     {
         ArgumentNullException.ThrowIfNull(setup);
-        var builder = new AgentCardBuilder();
-        setup(builder);
-        return services.AddA2AWellKnownAgent(builder.Build());
+        return services.AddSingleton(provider =>
+        {
+            var builder = new AgentCardBuilder();
+            setup(provider, builder);
+            return builder.Build();
+        });
     }
 
     /// <summary>

--- a/src/a2a-net.Server/Infrastructure/Services/A2AProtocolServer.cs
+++ b/src/a2a-net.Server/Infrastructure/Services/A2AProtocolServer.cs
@@ -70,6 +70,7 @@ public class A2AProtocolServer(string name, AgentCapabilities capabilities, ILog
                 Timestamp = DateTimeOffset.Now,
                 State = TaskState.Submitted
             },
+            Message = request.Params.Message,
             Notifications = request.Params.PushNotification
         },
         cancellationToken).ConfigureAwait(false);
@@ -94,6 +95,7 @@ public class A2AProtocolServer(string name, AgentCapabilities capabilities, ILog
                 Timestamp = DateTimeOffset.Now,
                 State = TaskState.Submitted
             },
+            Message = request.Params.Message,
             Notifications = request.Params.PushNotification
         },
         cancellationToken).ConfigureAwait(false);

--- a/src/a2a-net.Server/a2a-net.Server.csproj
+++ b/src/a2a-net.Server/a2a-net.Server.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Server</RootNamespace>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/tests/a2a-net.IntegrationTests/A2AWebServerStartup.cs
+++ b/tests/a2a-net.IntegrationTests/A2AWebServerStartup.cs
@@ -24,7 +24,7 @@ public class A2AWebServerStartup
     public override void ConfigureServices(IServiceCollection services)
     {
         services.AddLogging();
-        services.AddA2AWellKnownAgent(agent => agent
+        services.AddA2AWellKnownAgent((provider, agent) => agent
             .WithName("fake-agent-1")
             .WithDescription("fake-agent-1-description")
             .WithVersion("1.0.0")
@@ -36,7 +36,7 @@ public class A2AWebServerStartup
                 .WithId("fake-skill-id")
                 .WithName("fake-skill-name")
                 .WithDescription("fake-skill-description")));
-        services.AddA2AWellKnownAgent(agent => agent
+        services.AddA2AWellKnownAgent((provider, agent) => agent
             .WithName("fake-agent-2")
             .WithDescription("fake-agent-2-description")
             .WithVersion("1.0.0")

--- a/tests/a2a-net.IntegrationTests/Services/MockAgentRuntime.cs
+++ b/tests/a2a-net.IntegrationTests/Services/MockAgentRuntime.cs
@@ -19,12 +19,12 @@ internal class MockAgentRuntime
     : IAgentRuntime
 {
 
-    public async IAsyncEnumerable<AgentResponseContent> ExecuteAsync(Models.Task task,  [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<AgentResponseContent> ExecuteAsync(TaskRecord task,  [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await System.Threading.Tasks.Task.Delay(100);
+        await System.Threading.Tasks.Task.Delay(100, cancellationToken);
         yield break;
     }
 
-    public System.Threading.Tasks.Task CancelAsync(Models.Task task, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.CompletedTask;
+    public System.Threading.Tasks.Task CancelAsync(string taskId, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.CompletedTask;
 
 }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Adds a new method to the `IA2AProtocolServerBuilder` service to define a factory function used to create the `IAgentRuntime` to use
- Adds a new `Message` property to the `TaskRecord`, used to store the messages to invoke an agent with
- Updates the `IAgentRuntime`'s `ExecuteAsync` accept a `TaskRecord` as input parameter instead of a `Task`
- Fixes a minor security issue by setting the permissions of the `publish` CICD workflow
- Fixes the `IApplicationBuilderExtensions` by forcing the mapped endpoints to use the registered `JsonOptions`
