### PR TITLE
Fixed the `TaskRecordExtensions` to include `Artifacts` when converting a `TaskRecord` into a `Task`

### DIFF
--- a/src/a2a-net.Client.Asbtractions/a2a-net.Client.Abstractions.csproj
+++ b/src/a2a-net.Client.Asbtractions/a2a-net.Client.Abstractions.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Client</RootNamespace>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Client.Http/a2a-net.Client.Http.csproj
+++ b/src/a2a-net.Client.Http/a2a-net.Client.Http.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Client</RootNamespace>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Client.WebSocket/a2a-net.Client.WebSocket.csproj
+++ b/src/a2a-net.Client.WebSocket/a2a-net.Client.WebSocket.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Client.WebSocket</RootNamespace>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Client/a2a-net.Client.csproj
+++ b/src/a2a-net.Client/a2a-net.Client.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Client</RootNamespace>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Core/a2a-net.Core.csproj
+++ b/src/a2a-net.Core/a2a-net.Core.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Client</RootNamespace>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Server.AspNetCore/a2a-net.Server.AspNetCore.csproj
+++ b/src/a2a-net.Server.AspNetCore/a2a-net.Server.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 	<OutputType>Library</OutputType>
 	<RootNamespace>A2A.Server.AspNetCore</RootNamespace>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Server.Infrastructure.Abstractions/a2a-net.Server.Infrastructure.Abstractions.csproj
+++ b/src/a2a-net.Server.Infrastructure.Abstractions/a2a-net.Server.Infrastructure.Abstractions.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Server.Infrastructure</RootNamespace>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Server.Infrastructure.DistributedCache/a2a-net.Server.Infrastructure.DistributedCache.csproj
+++ b/src/a2a-net.Server.Infrastructure.DistributedCache/a2a-net.Server.Infrastructure.DistributedCache.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Server.Infrastructure.DistributedCache</RootNamespace>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/a2a-net.Server/Extensions/TaskRecordExtensions.cs
+++ b/src/a2a-net.Server/Extensions/TaskRecordExtensions.cs
@@ -23,13 +23,16 @@ public static class TaskRecordExtensions
     /// Converts the <see cref="TaskRecord"/> into a new <see cref="Models.Task"/>
     /// </summary>
     /// <param name="taskRecord">The <see cref="TaskRecord"/> to convert</param>
+    /// <param name="stateTransitionHistory">A boolean indicating whether or not the agent exposes status change history for tasks</param>
+    /// <param name="historyLength">The maximum length number of state transitions, if any, to be retrieved</param>
     /// <returns>A new <see cref="Models.Task"/></returns>
-    public static Models.Task AsTask(this TaskRecord taskRecord) => new()
+    public static Models.Task AsTask(this TaskRecord taskRecord, bool stateTransitionHistory = false, uint? historyLength = null) => new()
     {
         Id = taskRecord.Id,
         SessionId = taskRecord.SessionId,
         Status = taskRecord.Status,
-        History = taskRecord.History,
+        Artifacts = taskRecord.Artifacts,
+        History = stateTransitionHistory ? historyLength.HasValue && taskRecord.History != null ? [..taskRecord.History.TakeLast((int)historyLength.Value)] : taskRecord.History : null,
         Metadata = taskRecord.Metadata,
     };
 

--- a/src/a2a-net.Server/Infrastructure/Services/A2AProtocolServer.cs
+++ b/src/a2a-net.Server/Infrastructure/Services/A2AProtocolServer.cs
@@ -78,7 +78,7 @@ public class A2AProtocolServer(string name, AgentCapabilities capabilities, ILog
         return new()
         {
             Id = request.Id,
-            Result = task.AsTask()
+            Result = task.AsTask(Capabilities.StateTransitionHistory, request.Params.HistoryLength)
         };
     }
 
@@ -134,7 +134,7 @@ public class A2AProtocolServer(string name, AgentCapabilities capabilities, ILog
     public virtual async Task<RpcResponse<Models.Task>> GetTaskAsync(GetTaskRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var task = (await Tasks.GetAsync(request.Params.Id, cancellationToken).ConfigureAwait(false))?.AsTask();
+        var task = (await Tasks.GetAsync(request.Params.Id, cancellationToken).ConfigureAwait(false))?.AsTask(Capabilities.StateTransitionHistory);
         if (task == null) return new()
         {
             Id = request.Id,
@@ -173,7 +173,7 @@ public class A2AProtocolServer(string name, AgentCapabilities capabilities, ILog
         return new()
         {
             Id = request.Id,
-            Result = task.AsTask()
+            Result = task.AsTask(Capabilities.StateTransitionHistory)
         };
     }
 

--- a/src/a2a-net.Server/a2a-net.Server.csproj
+++ b/src/a2a-net.Server/a2a-net.Server.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>A2A.Server</RootNamespace>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/tests/a2a-net.IntegrationTests/Cases/A2AProtocolHttpClientTests.cs
+++ b/tests/a2a-net.IntegrationTests/Cases/A2AProtocolHttpClientTests.cs
@@ -69,6 +69,7 @@ public class A2AProtocolHttpClientTests
         response.Id.Should().Be(request.Id);
         response.Result.Should().NotBeNull();
         response.Result.Id.Should().Be(request.Params.Id);
+        response.Result.Artifacts.Should().NotBeNullOrEmpty();
     }
 
     [Fact]

--- a/tests/a2a-net.IntegrationTests/Services/MockAgentRuntime.cs
+++ b/tests/a2a-net.IntegrationTests/Services/MockAgentRuntime.cs
@@ -21,8 +21,27 @@ internal class MockAgentRuntime
 
     public async IAsyncEnumerable<AgentResponseContent> ExecuteAsync(TaskRecord task,  [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await System.Threading.Tasks.Task.Delay(100, cancellationToken);
-        yield break;
+        yield return new(new Artifact()
+        {
+            Parts =
+                [
+                    new TextPart("Foo")
+                ]
+        });
+        yield return new(new Artifact()
+        {
+            Parts =
+           [
+               new TextPart("Bar")
+           ]
+        });
+        yield return new(new Artifact()
+        {
+            Parts =
+           [
+               new TextPart("Baz")
+           ]
+        });
     }
 
     public System.Threading.Tasks.Task CancelAsync(string taskId, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.CompletedTask;

--- a/tests/a2a-net.IntegrationTests/Services/MockAgentRuntime.cs
+++ b/tests/a2a-net.IntegrationTests/Services/MockAgentRuntime.cs
@@ -21,6 +21,7 @@ internal class MockAgentRuntime
 
     public async IAsyncEnumerable<AgentResponseContent> ExecuteAsync(TaskRecord task,  [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        await System.Threading.Tasks.Task.Delay(50, cancellationToken);
         yield return new(new Artifact()
         {
             Parts =


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `TaskRecordExtensions` to include `Artifacts` when converting a `TaskRecord` into a `Task`
- Fixes the `TaskRecordExtensions` to check whether or not to include history, and to trim the status updates it contains based on the desired max history length