### PR TITLE
Fix http client streaming

### DIFF
--- a/src/a2a-net.Client.Http/Services/A2AProtocolHttpClient.cs
+++ b/src/a2a-net.Client.Http/Services/A2AProtocolHttpClient.cs
@@ -61,9 +61,9 @@ public class A2AProtocolHttpClient : IA2AProtocolClient, IDisposable
         using var content = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, MediaTypeNames.Application.Json);
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, Options.Endpoint) { Content = content };
         httpRequest.EnableWebAssemblyStreamingResponse();
-        using var httpResponse = await HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        using var httpResponse = await HttpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         httpResponse.EnsureSuccessStatusCode();
-        var httpResponseStream = await httpResponse.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
         using var streamReader = new StreamReader(await httpResponse.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false));
         while (!streamReader.EndOfStream)
         {
@@ -75,7 +75,7 @@ public class A2AProtocolHttpClient : IA2AProtocolClient, IDisposable
             {
                 e = JsonSerializer.Deserialize<RpcResponse<TaskEvent>>(json)!;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 continue;
             }

--- a/src/a2a-net.Client.Http/Services/A2AProtocolHttpClient.cs
+++ b/src/a2a-net.Client.Http/Services/A2AProtocolHttpClient.cs
@@ -75,7 +75,7 @@ public class A2AProtocolHttpClient : IA2AProtocolClient, IDisposable
             {
                 e = JsonSerializer.Deserialize<RpcResponse<TaskEvent>>(json)!;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 continue;
             }

--- a/src/a2a-net.Client.Http/Services/A2AProtocolHttpClient.cs
+++ b/src/a2a-net.Client.Http/Services/A2AProtocolHttpClient.cs
@@ -70,7 +70,16 @@ public class A2AProtocolHttpClient : IA2AProtocolClient, IDisposable
             var sseMessage = await streamReader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(sseMessage)) continue;
             var json = sseMessage["data: ".Length..].Trim();
-            var e = JsonSerializer.Deserialize<RpcResponse<TaskEvent>>(json)!;
+            RpcResponse<TaskEvent>? e = null;
+            try
+            {
+                e = JsonSerializer.Deserialize<RpcResponse<TaskEvent>>(json)!;
+            }
+            catch(Exception ex)
+            {
+                continue;
+            }
+
             yield return e;
         }
     }
@@ -145,7 +154,7 @@ public class A2AProtocolHttpClient : IA2AProtocolClient, IDisposable
         {
             if (disposing)
             {
-                
+
             }
             _disposed = true;
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
When streaming responses back, they aren't coming back "live" on the `IAsyncEnumerable` and attempt to deserialize raw SSE messages into A2A's `TaskEvent` format, which fails.

**Notes for Reviewers**:
If we want to do something special with the raw SSE events, we can - I elected to try/ignore deserializing everything on the pipe into the JsonRpc structure expected by A2A for simplicity

Fixes #16 