### PR TITLE
Input file support

### DIFF
--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Configuration/ApplicationOptions.cs
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Configuration/ApplicationOptions.cs
@@ -23,11 +23,13 @@ public class ApplicationOptions
     /// Gets/sets the URI of the A2A server to interact with
     /// </summary>
     [Required]
-    public Uri Server { get; set; } = null!;
+    public Uri? Server { get; set; } = null;
 
     /// <summary>
     /// Gets/sets the URI, if any, of the endpoint to send push notifications to
     /// </summary>
     public Uri? PushNotificationClient { get; set; }
+
+    public bool Streaming { get; set; }
 
 }

--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/MessageExtensions.cs
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/MessageExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright � 2025-Present the a2a-net Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+
+namespace A2A.Samples.SemanticKernel.Client;
+
+/// <summary>
+/// Defines extensions for <see cref="Message"/>s
+/// </summary>
+public static class MessageExtensions
+{
+
+    /// <summary>
+    /// Converts the <see cref="Message"/> into text
+    /// </summary>
+    /// <param name="message">The <see cref="Message"/> to convert</param>
+    /// <returns>The converted <see cref="Message"/></returns>
+    public static string? ToText(this Message message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        if (message.Parts == null) return null;
+        var textBuilder = new StringBuilder();
+        foreach (var part in message.Parts) textBuilder.Append(part.ToText());
+        return textBuilder.ToString();
+    }
+
+}

--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/PartExtensions.cs
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/PartExtensions.cs
@@ -1,0 +1,57 @@
+﻿// Copyright � 2025-Present the a2a-net Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+using System.Text.Json;
+
+namespace A2A.Samples.SemanticKernel.Client;
+
+/// <summary>
+/// Defines extensions for <see cref="Part"/>s
+/// </summary>
+public static class PartExtensions
+{
+
+    /// <summary>
+    /// Converts the <see cref="Part"/> into text
+    /// </summary>
+    /// <param name="part">The <see cref="Part"/> to convert</param>
+    /// <returns>The converted <see cref="Part"/></returns>
+    public static string ToText(this Part part)
+    {
+        ArgumentNullException.ThrowIfNull(part);
+        switch (part)
+        {
+            case TextPart textPart:
+                return textPart.Text;
+            case FilePart filePart:
+                var fileContentBuilder = new StringBuilder();
+                fileContentBuilder.AppendLine("----- FILE -----");
+                if (!string.IsNullOrWhiteSpace(filePart.File.Name)) fileContentBuilder.AppendLine($"Name    : {filePart.File.Name}");
+                if (!string.IsNullOrWhiteSpace(filePart.File.MimeType)) fileContentBuilder.AppendLine($"MIME    : {filePart.File.MimeType}");
+                if (!string.IsNullOrWhiteSpace(filePart.File.Bytes)) fileContentBuilder.AppendLine($"Size    : {Convert.FromBase64String(filePart.File.Bytes).Length}");
+                else if (filePart.File.Uri is not null) fileContentBuilder.AppendLine($"URI     : {filePart.File.Uri}");
+                fileContentBuilder.AppendLine("----------------");
+                return fileContentBuilder.ToString();
+            case DataPart dataPart:
+                var jsonContentBuilder = new StringBuilder();
+                jsonContentBuilder.AppendLine("```json");
+                jsonContentBuilder.AppendLine(JsonSerializer.Serialize(dataPart.Data));
+                jsonContentBuilder.AppendLine("```");
+                return jsonContentBuilder.ToString();
+            default:
+                throw new NotSupportedException($"The specified part type '{part.Type ?? "None"}' is not supported");
+        }
+    }
+
+}

--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Program.cs
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Program.cs
@@ -102,17 +102,27 @@ while (true)
         continue;
     }
 
+    var filePath = AnsiConsole.Ask<string>("[blue]File path (optional, <enter> to skip)>[/]", string.Empty).TrimStart('"').TrimEnd('"');
+    string? filename = !string.IsNullOrWhiteSpace(filePath) ? Path.GetFileName(filePath) : null;
+    var fileBytes = !string.IsNullOrWhiteSpace(filePath) ? System.IO.File.ReadAllBytes(filePath) : null;
+	
     spinnerCts = new();
 
     try
     {
+            var parts = new List<Part>() { new TextPart(prompt) };
+            if (!string.IsNullOrWhiteSpace(filePath))
+            {
+                parts.Add(new FilePart { File = new() { Bytes = Convert.ToBase64String(fileBytes!), Name = filename } });
+            }
+			
         var taskParams = new TaskSendParameters
         {
             SessionId = session,
             Message = new()
             {
                 Role = MessageRole.User,
-                Parts = [new TextPart(prompt)]
+                Parts = [.. parts]
             }
         };
 

--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Program.cs
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Program.cs
@@ -11,6 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using A2A.Events;
+using A2A.Samples.SemanticKernel.Client;
+
+using Microsoft.VisualStudio.Threading;
+
+using Spectre.Console.Extensions;
+
+using System.Text;
+
 var configuration = new ConfigurationBuilder()
     .AddCommandLine(args)
     .AddEnvironmentVariables()
@@ -19,62 +28,201 @@ var configuration = new ConfigurationBuilder()
     .Build();
 var applicationOptions = new ApplicationOptions();
 configuration.Bind(applicationOptions);
+ArgumentNullException.ThrowIfNull(applicationOptions.Server);
+
 using var httpClient = new HttpClient();
 var discoveryDocument = await httpClient.GetA2ADiscoveryDocumentAsync(applicationOptions.Server);
 var agent = discoveryDocument.Agents[0];
+
+// Allow `--streaming` to be a flag or a value
+if (applicationOptions.Streaming is false)
+{
+    var streamingArg = args.Select((v, i) => (i, v)).FirstOrDefault(i => i.v.Contains("streaming", StringComparison.OrdinalIgnoreCase));
+    if (streamingArg != default)
+    {
+        applicationOptions.Streaming = streamingArg.i + 1 >= args.Length || !bool.TryParse(args[streamingArg.i + 1], out var b) || b;
+    }
+}
+
 var services = new ServiceCollection();
+if (Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") is "Development")
+{
+    services.ConfigureHttpClientDefaults(b => b.ConfigureHttpClient(c => c.Timeout = TimeSpan.FromDays(1)));
+}
+
 services.AddA2AProtocolHttpClient(options =>
 {
     options.Endpoint = agent.Url.IsAbsoluteUri ? agent.Url : new(applicationOptions.Server, agent.Url);
 });
+
 var provider = services.BuildServiceProvider();
 var client = provider.GetRequiredService<IA2AProtocolClient>();
-var cancellationSource = new CancellationTokenSource();
+
+var agentCts = new CancellationTokenSource();
 AnsiConsole.Write(new FigletText("A2A Protocol Chat").Color(Color.Blue));
 AnsiConsole.MarkupLine("[gray]Type your prompts below. Press [bold]Ctrl+C[/] to exit.[/]\n");
+var responseSoFar = new StringBuilder();
+var session = Guid.NewGuid().ToString("N");
+
+var agentCommSpinnerDef = AnsiConsole.Status()
+            .Spinner(Spinner.Known.BouncingBar)
+            .SpinnerStyle(Style.Parse("green"));
+var toolSpinnerDef = AnsiConsole.Status()
+    .Spinner(Spinner.Known.SquareCorners)
+    .SpinnerStyle(Style.Parse("grey58"));
+
+CancellationTokenSource spinnerCts = new();
+System.Threading.Tasks.Task spinner = System.Threading.Tasks.Task.CompletedTask;
+void cancelSpinner()
+{
+    spinnerCts.Cancel();
+    try
+    {
+        spinner.Wait(spinnerCts.Token);
+    }
+    catch (Exception e) when (e is TaskCanceledException or OperationCanceledException)
+    {
+        // Ignore cancellation exceptions
+    }
+}
+
+void spinStopThen(Action runThis)
+{
+    cancelSpinner();
+    runThis();
+}
+
 while (true)
 {
+    cancelSpinner();
     var prompt = AnsiConsole.Ask<string>("[bold blue]User>[/]");
     if (string.IsNullOrWhiteSpace(prompt))
     {
         AnsiConsole.MarkupLine("[yellow]⚠️ Please enter a prompt.[/]");
         continue;
     }
-    var request = new SendTaskRequest
+
+    spinnerCts = new();
+
+    try
     {
-        Params = new()
+        var taskParams = new TaskSendParameters
         {
+            SessionId = session,
             Message = new()
             {
                 Role = MessageRole.User,
                 Parts = [new TextPart(prompt)]
-            },
-            PushNotification = applicationOptions.PushNotificationClient == null ? null : new()
-            {
-                Url = applicationOptions.PushNotificationClient
             }
-        }
-    };
-    try
-    {
-        var response = await client.SendTaskAsync(request, cancellationSource.Token);
-        if (response.Error != null)
+        };
+
+        if (applicationOptions.Streaming is true)
         {
-            AnsiConsole.MarkupLine($"[italic red]Agent>[/] [bold red]Error {response.Error.Code}:[/] {response.Error.Message}");
-        }
-        else if (response.Result?.Artifacts is { Count: > 0 })
-        {
-            foreach (var artifact in response.Result.Artifacts)
+            spinner = agentCommSpinnerDef
+                .StartAsync("Communicating with Agent...", ctx => System.Threading.Tasks.Task.Run(() => { while (true) ctx.Refresh(); }, spinnerCts.Token).WaitAsync(spinnerCts.Token));
+
+            var request = new SendTaskStreamingRequest { Params = taskParams };
+
+            bool firstArtifact = true;
+            try
             {
-                if (artifact.Parts != null)
+                await foreach (var response in client.SendTaskStreamingAsync(request, agentCts.Token))
                 {
-                    foreach (var part in artifact.Parts.OfType<TextPart>()) AnsiConsole.MarkupLine($"[bold green]Agent>[/] {part.Text}");
+                    if (response.Error is not null)
+                    {
+                        spinStopThen(() => AnsiConsole.MarkupLineInterpolated($"[red]❌ Error: {response.Error.Message}[/]"));
+                        continue;
+                    }
+
+                    if (response.Result is TaskArtifactUpdateEvent artifactEvent)
+                    {
+                        if (firstArtifact)
+                        {
+                            cancelSpinner();
+                            AnsiConsole.Markup($"[bold green]Agent>[/] ");
+                            firstArtifact = false;
+                        }
+                        else if (artifactEvent.Artifact.Append is false)
+                        {
+                            Console.WriteLine();
+                        }
+
+                        PrintArtifact(artifactEvent.Artifact);
+
+                        if (artifactEvent.Artifact.LastChunk is true)
+                        {
+                            Console.WriteLine();
+                        }
+                    }
+                    else if (response.Result is TaskStatusUpdateEvent evt)
+                    {
+                        var msg = evt.Status.Message?.ToText() ?? string.Empty;
+
+                        if (msg.Contains("ToolCalls:InProgress") is true && spinnerCts.IsCancellationRequested)
+                        {
+                            cancelSpinner();
+                            spinnerCts = new CancellationTokenSource();
+                            spinner = toolSpinnerDef.StartAsync("[grey23]Running tool...[/]", ctx => System.Threading.Tasks.Task.Run(() => { while (true) ctx.Refresh(); }, spinnerCts.Token).WaitAsync(spinnerCts.Token));
+
+                            continue;
+                        }
+                        else if (msg.Contains("ToolsCalls:Completed") is true && !spinnerCts.IsCancellationRequested)
+                        {
+                            cancelSpinner();
+                        }
+                        else if (!string.IsNullOrWhiteSpace(msg))
+                        {
+                            spinStopThen(() => AnsiConsole.MarkupLineInterpolated($"[grey23]{msg}[/]"));
+                        }
+
+                        if (evt.Final is true)
+                        {
+                            spinStopThen(() => Console.WriteLine());
+                        }
+                    }
+                    else
+                    {
+                        spinStopThen(() => AnsiConsole.MarkupLineInterpolated($"[red]Unknown event type: {response.Result?.GetType().Name}[/]"));
+                    }
                 }
+            }
+            finally
+            {
+                spinStopThen(() => Console.WriteLine());
             }
         }
         else
         {
-            AnsiConsole.MarkupLine("[italic gray]Agent> (no response received)[/]");
+            var request = new SendTaskRequest { Params = taskParams };
+
+            try
+            {
+                var task = await agentCommSpinnerDef
+                    .StartAsync("Communicating with Agent...", async ctx => await client.SendTaskAsync(request, agentCts.Token));
+
+                if (task.Error is not null)
+                {
+                    AnsiConsole.MarkupLineInterpolated($"[red]❌ Error: {task.Error.Message}[/]");
+                    continue;
+                }
+
+                if (task.Result?.Artifacts?.Count is not null and not 0)
+                {
+                    AnsiConsole.Markup($"[bold green]Agent>[/] ");
+                    foreach (var a in task.Result?.Artifacts ?? [])
+                    {
+                        PrintArtifact(a);
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]❌ Error: No artifacts found in response.[/]");
+                }
+            }
+            finally
+            {
+                spinStopThen(() => Console.WriteLine());
+            }
         }
     }
     catch (OperationCanceledException)
@@ -83,6 +231,14 @@ while (true)
     }
     catch (Exception ex)
     {
-        AnsiConsole.MarkupLineInterpolated($"[red]❌ Error: {ex.Message}[/]");
+        spinStopThen(() => AnsiConsole.MarkupLineInterpolated($"[red]❌ Error: {ex.Message}[/]"));
+    }
+}
+
+static void PrintArtifact(Artifact artifact)
+{
+    foreach (var p in artifact.Parts ?? [])
+    {
+        AnsiConsole.Markup(p.ToText()?.EscapeMarkup() ?? string.Empty);
     }
 }

--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Properties/launchSettings.json
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Properties/launchSettings.json
@@ -1,8 +1,18 @@
 {
   "profiles": {
-    "a2a-net.Samples.SemanticKernel.Client": {
+    "Synchronous client": {
       "commandName": "Project",
-      "commandLineArgs": "--Server http://localhost:5079 --PushNotificationClient http://localhost:5198"
+      "commandLineArgs": "--Server http://localhost:5079 --PushNotificationClient http://localhost:5198",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    },
+    "Streaming client": {
+      "commandName": "Project",
+      "commandLineArgs": "--Server http://localhost:5079 --PushNotificationClient http://localhost:5198 --streaming",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/src/a2a-net.Client.Asbtractions/Configuration/A2AProtocolClientOptions.cs
+++ b/src/a2a-net.Client.Asbtractions/Configuration/A2AProtocolClientOptions.cs
@@ -14,15 +14,29 @@
 namespace A2A.Client.Configuration;
 
 /// <summary>
-/// Represents the options used to configure an A2A client
+/// Represents the options used to configure an A2A client.
 /// </summary>
 public class A2AProtocolClientOptions
 {
-
     /// <summary>
-    /// Gets/sets the <see cref="Uri"/> that references the endpoint of the A2A server to use
+    /// Gets or sets the <see cref="Uri"/> that references the endpoint of the A2A server to use.
     /// </summary>
     public virtual Uri Endpoint { get; set; } = null!;
 
+    /// <summary>
+    /// Gets or sets a function that produces the authorization scheme and token used to authenticate requests.
+    /// </summary>
+    /// <remarks>
+    /// The returned tuple should contain:
+    /// <list type="bullet">
+    ///     <item>
+    ///         <description><c>Scheme</c> (e.g., "Bearer")</description>
+    ///     </item>
+    ///     <item>
+    ///         <description><c>Token</c> (the corresponding token string)</description>
+    ///     </item>
+    /// </list>
+    /// If this property is null, no authorization header is applied.
+    /// </remarks>
     public virtual Func<(string Scheme, string Token)>? Authorization { get; set; } = null;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Like Google's python CLI sample, this now provides the user - after they input their text prompt - to attach a file to go with the prompt (by providing the file path). This allows target agents to act on the uploaded file.

**Special notes for reviewers**:
Requires #19

**Additional information (if needed):**
For [this](https://github.com/user-attachments/assets/4582a878-a1f3-42da-b087-d7c07179a3f7) image (of me) we now can do:
```
User> Create an accessibility description for this image
File path (optional, <enter> to skip)> (): C:\...\WIN_20220810_13_20_58_Pro.jpg
Agent> The image shows a person holding two stickers in front of a white cabinet background. The person's face is blurred for privacy.

1. The first sticker depicts a stylized illustration of a famous character resembling Doc Brown from the "Back to the Future" series, with wild white
hair and a lab coat. Above the character's head, there is a futuristic car with lightning bolts, representing the DeLorean time machine from the
movie.

2. The second sticker is designed as a speech bubble coming from the character, containing the text: "CAME BACK FROM THE FUTURE AND IT IS
SERVERLESS." This phrase humorously implies that in the future, serverless technology is prevalent.

The person is holding these stickers with their left hand, and a ring is visible on their ring finger.
```