### PR TITLE
Fix JWK URL creation

### DIFF
--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Program.cs
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Program.cs
@@ -119,6 +119,7 @@ while (true)
         var taskParams = new TaskSendParameters
         {
             SessionId = session,
+            PushNotification = applicationOptions.PushNotificationClient is null ? null : new() { Url = applicationOptions.PushNotificationClient },
             Message = new()
             {
                 Role = MessageRole.User,

--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel/a2a-net.Samples.SemanticKernel.PushNotificationClient/Properties/launchSettings.json
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel/a2a-net.Samples.SemanticKernel.PushNotificationClient/Properties/launchSettings.json
@@ -4,7 +4,6 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "http://localhost:5198",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This PR makes our client conform to the jwk discovery endpoint in the same way as Google's sample client. Namely, _append_ `/.well-known/jwks.json` onto the agent URL vs treating it as a root path.

Fixes #23 

**Special notes for reviewers**:

**Additional information (if needed):**
Also
- Reverted a mistaken removal of setting `PushNotification` Task Send param value to get PNS to fully work.
- Removed browser launch from the PNS sample since it just throws a 400 as HTTP GET w/o verification token isn't valid.