### PR TITLE
Add 'reset command' handler

### DIFF
--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Program.cs
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Program.cs
@@ -102,20 +102,29 @@ while (true)
         continue;
     }
 
+    if (prompt is "/reset")
+    {
+        session = Guid.NewGuid().ToString("N");
+        responseSoFar.Clear();
+
+        AnsiConsole.MarkupLine("[yellow]⚠️ Chat history reset.[/]");
+        continue;
+    }
+
     var filePath = AnsiConsole.Ask<string>("[blue]File path (optional, <enter> to skip)>[/]", string.Empty).TrimStart('"').TrimEnd('"');
     string? filename = !string.IsNullOrWhiteSpace(filePath) ? Path.GetFileName(filePath) : null;
     var fileBytes = !string.IsNullOrWhiteSpace(filePath) ? System.IO.File.ReadAllBytes(filePath) : null;
-	
+
     spinnerCts = new();
 
     try
     {
-            var parts = new List<Part>() { new TextPart(prompt) };
-            if (!string.IsNullOrWhiteSpace(filePath))
-            {
-                parts.Add(new FilePart { File = new() { Bytes = Convert.ToBase64String(fileBytes!), Name = filename } });
-            }
-			
+        var parts = new List<Part>() { new TextPart(prompt) };
+        if (!string.IsNullOrWhiteSpace(filePath))
+        {
+            parts.Add(new FilePart { File = new() { Bytes = Convert.ToBase64String(fileBytes!), Name = filename } });
+        }
+
         var taskParams = new TaskSendParameters
         {
             SessionId = session,


### PR DESCRIPTION
Closes #26

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
When chatting with an agent we likely will want to reset all the chat history which, in A2A-land, is done by changing the Session ID. This adds the command `/reset` to create a new Session ID and reset the stored-up response stringbuilder.

**Special notes for reviewers**:
I'll be submitting a later PR to provide a "menu" output of sorts.

**Additional information (if needed):**
Open to other ways of doing this, but this was the lowest bar :)