### PR TITLE
Add agent card command

### DIFF
--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Program.cs
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/Program.cs
@@ -17,6 +17,7 @@ using A2A.Samples.SemanticKernel.Client;
 using Microsoft.VisualStudio.Threading;
 
 using Spectre.Console.Extensions;
+using Spectre.Console.Json;
 
 using System.Text;
 
@@ -67,6 +68,17 @@ var client = provider.GetRequiredService<IA2AProtocolClient>();
 
 var agentCts = new CancellationTokenSource();
 AnsiConsole.Write(new FigletText("A2A Protocol Chat").Color(Color.Blue));
+
+var menu = new Grid()
+    .AddColumn(new GridColumn().LeftAligned())
+    .AddColumn(new GridColumn().Centered())
+    .AddColumn(new GridColumn().LeftAligned())
+    .AddRow([new Text(string.Empty), new Text("Menu", new(Color.Purple_2, decoration: Decoration.Underline | Decoration.Bold))])
+    .AddRow("[bold yellow]/agent | /agents | /card | /cards[/]", string.Empty, "Display Card for targeted Agent")
+    .AddRow("[bold yellow]/reset[/]", string.Empty, "Resets the chat session (erases history)");
+AnsiConsole.Write(menu);
+Console.WriteLine();
+
 AnsiConsole.MarkupLine("[gray]Type your prompts below. Press [bold]Ctrl+C[/] to exit.[/]\n");
 var responseSoFar = new StringBuilder();
 var session = Guid.NewGuid().ToString("N");
@@ -269,16 +281,52 @@ while (true)
 
 void printAgentCards()
 {
-    AnsiConsole.MarkupLine("[bold green]Available Agents:[/]");
     foreach (var agent in agents)
     {
-        AnsiConsole.MarkupLineInterpolated($"[green]{agent.Name} - {agent.Description} - v{(string.IsNullOrWhiteSpace(agent.Version) ? "??" : agent.Version)}[/]");
-        AnsiConsole.MarkupLineInterpolated($"[green]  {nameof(agent.Url)} - {agent.Url}[/]");
-        AnsiConsole.MarkupLineInterpolated($"[green]  {nameof(agent.Authentication)} - {(agent.Authentication is null ? "None" : string.Join(", ", agent.Authentication!.Schemes))}[/]");
-        AnsiConsole.MarkupLineInterpolated($"[green]  {nameof(agent.Capabilities)} - {nameof(agent.Capabilities.Streaming)}: {(agent.Capabilities.Streaming ? "✅" : "❌")} | {nameof(agent.Capabilities.PushNotifications)}: {(agent.Capabilities.PushNotifications ? "✅" : "❌")} | {nameof(agent.Capabilities.StateTransitionHistory)}: {(agent.Capabilities.StateTransitionHistory ? "✅" : "❌")}[/]");
-        AnsiConsole.MarkupLineInterpolated($"[green]  {nameof(agent.DocumentationUrl)} - {agent.DocumentationUrl}[/]");
-        AnsiConsole.MarkupLineInterpolated($"[green]  {nameof(agent.Skills)} - {(agent.Skills.Count is 0 ? "None" : string.Join(", ", agent.Skills.Select(s => s.Name)))}[/]");
+        printCard(agent);
     }
+}
+
+void printCard(AgentCard card)
+{
+    var detailsTable = new Table().AddColumn(string.Empty, c => c.RightAligned()).AddColumn(string.Empty).HideHeaders().NoBorder();
+    if (card.Authentication is null)
+    {
+        detailsTable
+            .AddRow($"[bold]{nameof(card.Authentication)}:[/]", "None");
+    }
+    else
+    {
+        var authDetailsTable = new Table().AddColumn("[underline]Schemes[/]", c => c.NoWrap().Centered()).AddColumn(new TableColumn(new Markup("[underline]Credentials[/]").Centered())).NoBorder().RoundedBorder()
+            .AddRow(new Text(card.Authentication!.Schemes?.Count is null or 0 ? "None" : string.Join('\n', card.Authentication!.Schemes)),
+                !string.IsNullOrWhiteSpace(card.Authentication.Credentials) ? new JsonText(card.Authentication.Credentials) : new Text("None"));
+
+        detailsTable.AddRow(new Markup($"\n[bold]{nameof(card.Authentication)}:[/]"), authDetailsTable);
+    }
+
+    detailsTable
+        .AddRow($"[bold]{nameof(card.Capabilities.Streaming)}:[/]", card.Capabilities.Streaming ? Emoji.Known.CheckMarkButton : Emoji.Known.CrossMarkButton)
+        .AddRow($"[bold]{nameof(card.Capabilities.PushNotifications)}:[/]", card.Capabilities.PushNotifications ? Emoji.Known.CheckMarkButton : Emoji.Known.CrossMarkButton)
+        .AddRow($"[bold]{nameof(card.Capabilities.StateTransitionHistory)}:[/]", card.Capabilities.StateTransitionHistory ? Emoji.Known.CheckMarkButton : Emoji.Known.CrossMarkButton)
+        .AddRow(new Markup($"[bold]{nameof(card.Skills)}:[/]"), new Text(card.Skills.Count is 0 ? "None" : string.Join("\n", card.Skills.OrderBy(s => s.Name).Select(s => $"{Emoji.Known.Wrench} {s.Name}{(string.IsNullOrWhiteSpace(s.Description) ? string.Empty : $" - {s.Description}")}"))));
+
+    var table = new Table().AddColumn(new(string.Empty) { Width = 50 }).AddColumn(string.Empty).HideHeaders().NoBorder();
+    table.AddRow(new Markup($"[blue]{card.Provider?.Organization ?? string.Empty}\n{card.Provider?.Url}[/]"), new Markup($"[bold blue]{card.Name}[/]\n[blue]v{card.Version}[/]").RightJustified());
+    table.AddRow(
+        new Table().AddColumn(string.Empty).HideHeaders().NoBorder()
+            .AddRow(new Markup($"[blue]{card.Description}[/]").RightJustified())
+            .AddRow(new Text(card.DocumentationUrl?.ToString() ?? string.Empty).RightJustified()),
+        detailsTable
+    );
+
+    table = new Table().AddColumn(string.Empty).HideHeaders().RoundedBorder()
+        .AddRow(table);
+
+    table = new Table().AddColumn(string.Empty).HideHeaders().HorizontalBorder()
+        .AddRow(new Markup(card.Url.ToString(), new Style(Color.Green, decoration: Decoration.Underline | Decoration.Bold, link: card.Url.ToString())))
+        .AddRow(table);
+
+    AnsiConsole.Write(table);
 }
 
 static async System.Threading.Tasks.Task PrintArtifactAsync(Artifact artifact)

--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/a2a-net.Samples.SemanticKernel.Client.csproj
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel.Client/a2a-net.Samples.SemanticKernel.Client.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
+    <PackageReference Include="Spectre.Console.Json" Version="0.50.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/semantic-kernel/a2a-net.Samples.SemanticKernel/a2a-net.Samples.SemanticKernel.PushNotificationClient/Program.cs
+++ b/samples/semantic-kernel/a2a-net.Samples.SemanticKernel/a2a-net.Samples.SemanticKernel.PushNotificationClient/Program.cs
@@ -28,11 +28,11 @@ app.MapPost("/", async (HttpRequest request, HttpClient httpClient, IOptions<App
     var jwksUri = new UriBuilder(options.Value.Server);
     if (jwksUri.Uri.IsAbsoluteUri)
     {
-        jwksUri.Query = request?.QueryString.Value ?? httpClient.BaseAddress?.Query;
+        jwksUri.Query = request.QueryString.Value ?? httpClient.BaseAddress?.Query;
         jwksUri.Path = $"{jwksUri.Path.TrimEnd('/')}/{jwksPath}";
     }
 
-    var json = await httpClient.GetStringAsync(jwksUri.Uri, request?.HttpContext.RequestAborted ?? default);
+    var json = await httpClient.GetStringAsync(jwksUri.Uri, request.HttpContext.RequestAborted);
     var jwks = new JsonWebKeySet(json);
     using var reader = new StreamReader(request.Body);
     var payload = await reader.ReadToEndAsync(request.HttpContext.RequestAborted);


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Closes #27 by providing a way to view the card of the target agent, to confirm it's reporting what an agent developer expects it to.

**Special notes for reviewers**:
Outputs a card like this for each agent returned by the initial discovery call:
![image](https://github.com/user-attachments/assets/a8f71fac-6621-426d-8987-2ad64b865dc2)

**Additional information (if needed):**
I also added a new Menu that outputs on startup since we have a few commands now:
![image](https://github.com/user-attachments/assets/de49663e-1024-46bf-b8c7-87d0ac32757d)
