### PR TITLE
Fix RPC method names for messages

### DIFF
--- a/src/a2a-net.Core/A2AProtocol.cs
+++ b/src/a2a-net.Core/A2AProtocol.cs
@@ -31,14 +31,14 @@ public static class A2AProtocol
         public static class Messages
         {
 
-            const string Prefix = "messages/";
+            const string Prefix = "message/";
 
             /// <summary>
-            /// The name of the method for sending a message to an agent ("messages/send").
+            /// The name of the method for sending a message to an agent ("message/send").
             /// </summary>
             public const string Send = Prefix + "send";
             /// <summary>
-            /// The name of the method for streaming messages to an agent ("messages/stream").
+            /// The name of the method for streaming messages to an agent ("message/stream").
             /// </summary>
             public const string Stream = Prefix + "stream";
         }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
It updates the RPC method names to align with the existing [specifications](https://a2aproject.github.io/A2A/0.2.2/specification/#71-messagesend).